### PR TITLE
Allow to override order expiration date

### DIFF
--- a/pretix_cashpayment/payment.py
+++ b/pretix_cashpayment/payment.py
@@ -52,9 +52,11 @@ class CashPayment(BasePaymentProvider):
             ),
             (
                 "provider_last_payment",
-                RelativeDateTimeField(required=False,
-                                      label=_('Override order expiration date'),
-                                      help_text=_('The order expiration date will only be changed by this setting if it is later than the date set for the event generally.'),
+                RelativeDateTimeField(
+                    required=False,
+                    label=_('Override order expiration date'),
+                    help_text=_('The order expiration date will only be changed by this setting if it is later than the date set for the event generally.'),
+                )
             ),
         ]
         return OrderedDict(
@@ -106,12 +108,12 @@ class CashPayment(BasePaymentProvider):
     def execute_payment(self, request: HttpRequest, payment: OrderPayment):
         order = payment.order
 
-        custom_expires = self.settings.get("provider_last_payment, as_type=RelativeDateWrapper)
+        custom_expires = self.settings.get("provider_last_payment", as_type=RelativeDateWrapper)
         if custom_expires:
             if self.event.has_subevents:
-	        subevents = order.event.subevents.filter(id__in=order.positions.values_list('subevent_id', flat=True))
-	    else:
-	        subevents = None
+                subevents = order.event.subevents.filter(id__in=order.positions.values_list('subevent_id', flat=True))
+            else:
+                subevents = None
             self._set_custom_expires(order, custom_expires, subevents)
     
     def _set_custom_expires(self, order: Order, reldate: RelativeDateWrapper, subevents=None):

--- a/pretix_cashpayment/payment.py
+++ b/pretix_cashpayment/payment.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.http import HttpRequest
 from django.template.loader import get_template
 from django.utils.translation import gettext_lazy as _
-from i18nfield.fields import I18nFormField, I18nTextarea
+from i18nfield.fields import I18nFormField, I18nTextarea, I18nTextInput
 from i18nfield.strings import LazyI18nString
 
 from pretix.base.models import OrderPayment
@@ -20,15 +20,31 @@ class CashPayment(BasePaymentProvider):
     def test_mode_message(self):
         return _('In test mode, you can just manually mark this order as paid in the backend after it has been '
                  'created.')
+    
+    @property
+    def public_name(self) -> str:
+        return str(self.settings.get("public_name", as_type=LazyI18nString)) or _(
+            "Cash Payment"
+        )
 
     @property
     def settings_form_fields(self):
-        form_field = I18nFormField(
-            label=_('Payment information text'),
-            widget=I18nTextarea,
-        )
+        fields = [
+            (
+                "public_name",
+                I18nFormField(
+                    label=_("Payment method name"), widget=I18nTextInput, required=False
+                ),
+            ),
+            (
+                "information_text",
+                I18nFormField(
+                    label=_('Payment information text'),widget=I18nTextarea,
+                ),
+            ),
+        ]
         return OrderedDict(
-            list(super().settings_form_fields.items()) + [('information_text', form_field)]
+            list(super().settings_form_fields.items()) + fields
         )
 
     def payment_form_render(self, request) -> str:


### PR DESCRIPTION
added additional field to settings for "custom order expiration"

if set to anything other than "None", whenever the payment method is used, it applies this custom expiration to the order. If guests don't pick up their order at the venue until then, tickets go back into the pool.

useful for when you want to offer paying for tickets at the venue without having failed orders from different payment methods block your quota.